### PR TITLE
Update OpenSsl.php - Use OPENSSL constants rather than a bool

### DIFF
--- a/Crypto/OpenSsl.php
+++ b/Crypto/OpenSsl.php
@@ -61,7 +61,7 @@ class OpenSsl
         $ivSize = openssl_cipher_iv_length($method);
 
         $iv = openssl_random_pseudo_bytes($ivSize);
-        return $iv . openssl_encrypt($plain, $method, $key, true, $iv);
+        return $iv . openssl_encrypt($plain, $method, $key, OPENSSL_RAW_DATA, $iv);
     }
 
     /**
@@ -80,6 +80,6 @@ class OpenSsl
         $iv = mb_substr($cipher, 0, $ivSize, '8bit');
 
         $cipher = mb_substr($cipher, $ivSize, null, '8bit');
-        return openssl_decrypt($cipher, $method, $key, true, $iv);
+        return openssl_decrypt($cipher, $method, $key, OPENSSL_RAW_DATA, $iv);
     }
 }


### PR DESCRIPTION
You should be using the constant `OPENSSL_RAW_DATA` rather than `true` to specify option flags.

OPENSSL_RAW_DATA is the equivalent of the value of 1
OPENSSL_ZERO_PADDING is the equivalent of the value of 2
(If you want both, you need to provide the value of 3)